### PR TITLE
Auto-select BM64 device

### DIFF
--- a/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
@@ -48,10 +48,22 @@ class HomeFragment : Fragment() {
     private fun startListening() {
         statusText.text = getString(R.string.waiting_for_bm64)
         val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
-        val address = prefs.getString("device_address", null) ?: return
+        var address = prefs.getString("device_address", null)
+        if (address == null) {
+            address = findFirstBm64Address()?.also {
+                prefs.edit().putString("device_address", it).apply()
+            }
+        }
+        if (address == null) return
         val adapter = BluetoothAdapter.getDefaultAdapter()
         val device = adapter.getRemoteDevice(address)
         gatt = device.connectGatt(requireContext(), false, gattCallback)
+    }
+
+    private fun findFirstBm64Address(): String? {
+        val adapter = BluetoothAdapter.getDefaultAdapter() ?: return null
+        val device = adapter.bondedDevices.firstOrNull { it.name.equals("BM64", true) }
+        return device?.address
     }
 
     private val gattCallback = object : BluetoothGattCallback() {

--- a/app/src/main/java/at/plankt0n/openbm64/SetupFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/SetupFragment.kt
@@ -38,7 +38,6 @@ class SetupFragment : Fragment() {
         button.setOnClickListener {
             startActivity(Intent(Settings.ACTION_BLUETOOTH_SETTINGS))
         }
-        checkPermissionAndLoadDevices()
 
         spinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View?, position: Int, id: Long) {
@@ -52,6 +51,8 @@ class SetupFragment : Fragment() {
 
             override fun onNothingSelected(parent: AdapterView<*>) {}
         }
+
+        checkPermissionAndLoadDevices()
     }
 
     private fun checkPermissionAndLoadDevices() {
@@ -95,5 +96,15 @@ class SetupFragment : Fragment() {
         val arrayAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, devices)
         arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinner.adapter = arrayAdapter
+
+        val firstBm64 = adapter?.bondedDevices?.firstOrNull { it.name.equals("BM64", true) }
+        firstBm64?.let {
+            PreferenceManager.getDefaultSharedPreferences(requireContext())
+                .edit()
+                .putString("device_address", it.address)
+                .apply()
+            val index = devices.indexOf("${it.name} - ${it.address}")
+            if (index >= 0) spinner.setSelection(index)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- auto-detect the first paired device named BM64
- pre-select that device in SetupFragment when permissions are granted

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a89a110f4832fbd45598e643e4cad