### PR TITLE
Add history screen with DB sync

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
     implementation(libs.androidx.preference)
+    implementation(libs.androidx.documentfile)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
@@ -1,0 +1,25 @@
+package at.plankt0n.openbm64
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ListView
+import androidx.fragment.app.Fragment
+import at.plankt0n.openbm64.db.MeasurementDbHelper
+
+class HistoryFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_history, container, false)
+        val listView: ListView = view.findViewById(R.id.list_history)
+        val dbHelper = MeasurementDbHelper(requireContext())
+        val measurements = dbHelper.getAll()
+        listView.adapter = MeasurementAdapter(requireContext(), measurements)
+        return view
+    }
+}

--- a/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
@@ -10,7 +10,6 @@ import android.widget.ListView
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
 import at.plankt0n.openbm64.db.Measurement
-import at.plankt0n.openbm64.db.MeasurementDbHelper
 import java.io.File
 
 class HistoryFragment : Fragment() {
@@ -55,10 +54,6 @@ class HistoryFragment : Fragment() {
                     lines.mapNotNull { parseCsvLine(it) }.forEach { list.add(it) }
                 }
             }
-        }
-        if (list.isEmpty()) {
-            val dbHelper = MeasurementDbHelper(requireContext())
-            list.addAll(dbHelper.getAll())
         }
         return list
     }

--- a/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
@@ -10,7 +10,7 @@ import android.widget.ListView
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
 import at.plankt0n.openbm64.db.Measurement
-import java.io.File
+import at.plankt0n.openbm64.StorageHelper
 
 class HistoryFragment : Fragment() {
 
@@ -48,7 +48,7 @@ class HistoryFragment : Fragment() {
                 }
             }
         } else {
-            val file = File(requireContext().filesDir, "measurements.csv")
+            val file = StorageHelper.internalCsvFile(requireContext())
             if (file.exists()) {
                 file.bufferedReader().useLines { lines ->
                     lines.mapNotNull { parseCsvLine(it) }.forEach { list.add(it) }

--- a/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
@@ -1,25 +1,73 @@
 package at.plankt0n.openbm64
 
+import android.content.Context
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ListView
+import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
+import at.plankt0n.openbm64.db.Measurement
 import at.plankt0n.openbm64.db.MeasurementDbHelper
+import java.io.File
 
 class HistoryFragment : Fragment() {
+
+    private fun parseCsvLine(line: String): Measurement? {
+        val parts = line.split(",")
+        if (parts.size < 4) return null
+        val pulse = parts.getOrNull(4)?.toIntOrNull()
+        return Measurement(
+            timestamp = parts[0],
+            systole = parts[1].toIntOrNull() ?: return null,
+            diastole = parts[2].toIntOrNull() ?: return null,
+            map = parts[3].toDoubleOrNull() ?: return null,
+            pulse = pulse,
+            raw = ByteArray(0)
+        )
+    }
+
+    private fun loadMeasurements(): List<Measurement> {
+        val p = requireContext().getSharedPreferences("settings", Context.MODE_PRIVATE)
+        val list = mutableListOf<Measurement>()
+        if (p.getBoolean(SettingsFragment.KEY_SAVE_EXTERNAL, false)) {
+            val dirUri = p.getString(SettingsFragment.KEY_DIR, null)
+            if (dirUri != null) {
+                val dir = DocumentFile.fromTreeUri(requireContext(), Uri.parse(dirUri))
+                val file = dir?.findFile("measurements.csv")
+                file?.uri?.let { uri ->
+                    requireContext().contentResolver.openInputStream(uri)?.bufferedReader()?.useLines { lines ->
+                        lines.mapNotNull { parseCsvLine(it) }.forEach { list.add(it) }
+                    }
+                }
+            }
+        } else {
+            val file = File(requireContext().filesDir, "measurements.csv")
+            if (file.exists()) {
+                file.bufferedReader().useLines { lines ->
+                    lines.mapNotNull { parseCsvLine(it) }.forEach { list.add(it) }
+                }
+            }
+        }
+        if (list.isEmpty()) {
+            val dbHelper = MeasurementDbHelper(requireContext())
+            list.addAll(dbHelper.getAll())
+        }
+        return list
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
-        savedInstanceState: Bundle?
+        savedInstanceState: Bundle?,
     ): View {
         val view = inflater.inflate(R.layout.fragment_history, container, false)
         val listView: ListView = view.findViewById(R.id.list_history)
-        val dbHelper = MeasurementDbHelper(requireContext())
-        val measurements = dbHelper.getAll()
+        val measurements = loadMeasurements()
         listView.adapter = MeasurementAdapter(requireContext(), measurements)
         return view
     }
 }
+

--- a/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HistoryFragment.kt
@@ -18,14 +18,19 @@ class HistoryFragment : Fragment() {
     private fun parseCsvLine(line: String): Measurement? {
         val parts = line.split(",")
         if (parts.size < 4) return null
-        val pulse = parts.getOrNull(4)?.toIntOrNull()
+        val pulse = parts.getOrNull(4)?.takeIf { it.isNotEmpty() }?.toIntOrNull()
+        val raw = if (parts.size > 5) {
+            parts[5].chunked(2).mapNotNull {
+                it.toIntOrNull(16)?.toByte()
+            }.toByteArray()
+        } else ByteArray(0)
         return Measurement(
             timestamp = parts[0],
             systole = parts[1].toIntOrNull() ?: return null,
             diastole = parts[2].toIntOrNull() ?: return null,
             map = parts[3].toDoubleOrNull() ?: return null,
             pulse = pulse,
-            raw = ByteArray(0)
+            raw = raw
         )
     }
 

--- a/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
@@ -253,6 +253,7 @@ class HomeFragment : Fragment() {
             override fun run() {
                 remaining--
                 if (remaining <= 0) {
+                    activity?.runOnUiThread { logView?.text = "" }
                     showWaiting()
                     if (autoRunning) handler.post(connectRunnable)
                     countdown = null

--- a/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
@@ -169,6 +169,12 @@ class HomeFragment : Fragment() {
     }
 
     private fun exportCsv(m: Measurement) {
+        val line = "${m.timestamp},${m.systole},${m.diastole},${m.map},${m.pulse ?: ""}\n"
+        // always write to internal file
+        requireContext().openFileOutput("measurements.csv", Context.MODE_APPEND).use {
+            it.write(line.toByteArray())
+        }
+
         val p = prefs ?: return
         if (!p.getBoolean(SettingsFragment.KEY_SAVE_EXTERNAL, false)) return
         val dirUri = p.getString(SettingsFragment.KEY_DIR, null) ?: return
@@ -179,7 +185,6 @@ class HomeFragment : Fragment() {
         }
         file?.uri?.let { uri ->
             requireContext().contentResolver.openOutputStream(uri, "wa")?.use { out ->
-                val line = "${m.timestamp},${m.systole},${m.diastole},${m.map},${m.pulse ?: ""}\n"
                 out.write(line.toByteArray())
             }
         }

--- a/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
@@ -22,6 +22,7 @@ import androidx.documentfile.provider.DocumentFile
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
+import at.plankt0n.openbm64.StorageHelper
 import java.util.UUID
 
 class HomeFragment : Fragment() {
@@ -198,11 +199,10 @@ class HomeFragment : Fragment() {
 
     private fun exportCsv(m: Measurement) {
         val rawHex = m.raw.joinToString("") { String.format("%02X", it) }
-        val line = "${m.timestamp},${m.systole},${m.diastole},${m.map},${m.pulse ?: ""},$rawHex\n"
-        // always write to internal file
-        requireContext().openFileOutput("measurements.csv", Context.MODE_APPEND).use {
-            it.write(line.toByteArray())
-        }
+        val line = "${'$'}{m.timestamp},${'$'}{m.systole},${'$'}{m.diastole},${'$'}{m.map},${'$'}{m.pulse ?: ""},${'$'}rawHex\n"
+        // always write to internal file under Android/media
+        val internal = StorageHelper.internalCsvFile(requireContext())
+        internal.appendText(line)
 
         val p = prefs ?: return
         if (!p.getBoolean(SettingsFragment.KEY_SAVE_EXTERNAL, false)) return

--- a/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
@@ -169,7 +169,8 @@ class HomeFragment : Fragment() {
     }
 
     private fun exportCsv(m: Measurement) {
-        val line = "${m.timestamp},${m.systole},${m.diastole},${m.map},${m.pulse ?: ""}\n"
+        val rawHex = m.raw.joinToString("") { String.format("%02X", it) }
+        val line = "${m.timestamp},${m.systole},${m.diastole},${m.map},${m.pulse ?: ""},$rawHex\n"
         // always write to internal file
         requireContext().openFileOutput("measurements.csv", Context.MODE_APPEND).use {
             it.write(line.toByteArray())

--- a/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
@@ -209,7 +209,7 @@ class HomeFragment : Fragment() {
 
     private fun exportCsv(m: Measurement) {
         val rawHex = m.raw.joinToString("") { String.format("%02X", it) }
-        val line = "${'$'}{m.timestamp},${'$'}{m.systole},${'$'}{m.diastole},${'$'}{m.map},${'$'}{m.pulse ?: ""},${'$'}rawHex\n"
+        val line = "${m.timestamp},${m.systole},${m.diastole},${m.map},${m.pulse ?: ""},$rawHex\n"
         // always write to internal file under Android/media
         val internal = StorageHelper.internalCsvFile(requireContext())
         internal.appendText(line)

--- a/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
@@ -51,12 +51,6 @@ class HomeFragment : Fragment() {
     ): View {
         val view = inflater.inflate(R.layout.fragment_home, container, false)
         view.findViewById<Button>(R.id.button_read).setOnClickListener { startReadingHistory() }
-        view.findViewById<Button>(R.id.button_history).setOnClickListener {
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, HistoryFragment())
-                .addToBackStack(null)
-                .commit()
-        }
         dbHelper = MeasurementDbHelper(requireContext())
         logView = view.findViewById(R.id.text_log)
         return view

--- a/app/src/main/java/at/plankt0n/openbm64/MainActivity.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class MainActivity : AppCompatActivity() {
 
@@ -18,10 +19,33 @@ class MainActivity : AppCompatActivity() {
 
         checkAndRequestPermissions()
 
+        val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_nav)
+        bottomNav.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.nav_home -> {
+                    supportFragmentManager.beginTransaction()
+                        .replace(R.id.fragment_container, HomeFragment())
+                        .commit()
+                    true
+                }
+                R.id.nav_history -> {
+                    supportFragmentManager.beginTransaction()
+                        .replace(R.id.fragment_container, HistoryFragment())
+                        .commit()
+                    true
+                }
+                R.id.nav_settings -> {
+                    supportFragmentManager.beginTransaction()
+                        .replace(R.id.fragment_container, SettingsFragment())
+                        .commit()
+                    true
+                }
+                else -> false
+            }
+        }
+
         if (savedInstanceState == null) {
-            supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, HomeFragment())
-                .commit()
+            bottomNav.selectedItemId = R.id.nav_home
         }
     }
 

--- a/app/src/main/java/at/plankt0n/openbm64/MeasurementAdapter.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/MeasurementAdapter.kt
@@ -1,0 +1,28 @@
+package at.plankt0n.openbm64
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import at.plankt0n.openbm64.db.Measurement
+
+class MeasurementAdapter(
+    context: Context,
+    measurements: List<Measurement>
+) : ArrayAdapter<Measurement>(context, 0, measurements) {
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = convertView ?: LayoutInflater.from(context)
+            .inflate(R.layout.item_measurement, parent, false)
+
+        val item = getItem(position)!!
+        view.findViewById<TextView>(R.id.cell_timestamp).text = item.timestamp
+        view.findViewById<TextView>(R.id.cell_systole).text = item.systole.toString()
+        view.findViewById<TextView>(R.id.cell_diastole).text = item.diastole.toString()
+        view.findViewById<TextView>(R.id.cell_map).text = item.map.toString()
+        view.findViewById<TextView>(R.id.cell_pulse).text = item.pulse?.toString() ?: ""
+        return view
+    }
+}

--- a/app/src/main/java/at/plankt0n/openbm64/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/SettingsFragment.kt
@@ -17,7 +17,7 @@ import androidx.core.view.isVisible
 import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
 import at.plankt0n.openbm64.db.MeasurementDbHelper
-import java.io.File
+import at.plankt0n.openbm64.StorageHelper
 
 class SettingsFragment : Fragment() {
 
@@ -145,7 +145,7 @@ class SettingsFragment : Fragment() {
     }
 
     private fun deleteCsv() {
-        File(requireContext().filesDir, "measurements.csv").delete()
+        StorageHelper.internalCsvFile(requireContext()).delete()
         val dirUri = prefs.getString(KEY_DIR, null)
         if (dirUri != null) {
             val dir = DocumentFile.fromTreeUri(requireContext(), Uri.parse(dirUri)) ?: return
@@ -164,7 +164,7 @@ class SettingsFragment : Fragment() {
     }
 
     private fun moveFileToExternal(uri: Uri) {
-        val internal = File(requireContext().filesDir, "measurements.csv")
+        val internal = StorageHelper.internalCsvFile(requireContext())
         if (!internal.exists()) return
         val dir = DocumentFile.fromTreeUri(requireContext(), uri) ?: return
         var file = dir.findFile("measurements.csv")
@@ -180,7 +180,7 @@ class SettingsFragment : Fragment() {
     }
 
     private fun moveFileToInternal(uri: Uri) {
-        val internal = File(requireContext().filesDir, "measurements.csv")
+        val internal = StorageHelper.internalCsvFile(requireContext())
         val dir = DocumentFile.fromTreeUri(requireContext(), uri) ?: return
         val file = dir.findFile("measurements.csv") ?: return
         requireContext().contentResolver.openInputStream(file.uri)?.use { input ->

--- a/app/src/main/java/at/plankt0n/openbm64/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/SettingsFragment.kt
@@ -1,0 +1,17 @@
+package at.plankt0n.openbm64
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class SettingsFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        return inflater.inflate(R.layout.fragment_settings, container, false)
+    }
+}

--- a/app/src/main/java/at/plankt0n/openbm64/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/SettingsFragment.kt
@@ -1,17 +1,103 @@
 package at.plankt0n.openbm64
 
+import android.app.AlertDialog
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.Switch
+import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.view.isVisible
+import androidx.documentfile.provider.DocumentFile
 import androidx.fragment.app.Fragment
+import at.plankt0n.openbm64.db.MeasurementDbHelper
 
 class SettingsFragment : Fragment() {
+
+    private lateinit var prefs: SharedPreferences
+    private lateinit var saveExternalSwitch: Switch
+    private lateinit var externalLayout: View
+    private lateinit var externalPath: TextView
+
+    private val openDirectory =
+        registerForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+            if (uri != null) {
+                val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                        Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                requireContext().contentResolver.takePersistableUriPermission(uri, flags)
+                prefs.edit().putString(KEY_DIR, uri.toString()).apply()
+                updateExternalPath(uri)
+            }
+        }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        return inflater.inflate(R.layout.fragment_settings, container, false)
+        val view = inflater.inflate(R.layout.fragment_settings, container, false)
+
+        prefs = requireContext().getSharedPreferences("settings", Context.MODE_PRIVATE)
+
+        saveExternalSwitch = view.findViewById(R.id.switch_save_external)
+        externalLayout = view.findViewById(R.id.layout_external)
+        externalPath = view.findViewById(R.id.text_external_path)
+
+        saveExternalSwitch.isChecked = prefs.getBoolean(KEY_SAVE_EXTERNAL, false)
+        externalLayout.isVisible = saveExternalSwitch.isChecked
+
+        prefs.getString(KEY_DIR, null)?.let { updateExternalPath(Uri.parse(it)) }
+
+        saveExternalSwitch.setOnCheckedChangeListener { _, isChecked ->
+            prefs.edit().putBoolean(KEY_SAVE_EXTERNAL, isChecked).apply()
+            externalLayout.isVisible = isChecked
+            if (isChecked && prefs.getString(KEY_DIR, null) == null) {
+                openDirectory.launch(null)
+            }
+        }
+
+        view.findViewById<Button>(R.id.button_choose_folder).setOnClickListener {
+            openDirectory.launch(null)
+        }
+
+        view.findViewById<Button>(R.id.button_clear_db).setOnClickListener {
+            confirmAndClearDatabase()
+        }
+
+        return view
+    }
+
+    private fun confirmAndClearDatabase() {
+        AlertDialog.Builder(requireContext())
+            .setMessage(R.string.confirm_delete)
+            .setPositiveButton(android.R.string.ok) { _, _ ->
+                MeasurementDbHelper(requireContext()).writableDatabase.use {
+                    it.delete("measurements", null, null)
+                }
+                deleteCsv()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun deleteCsv() {
+        val dirUri = prefs.getString(KEY_DIR, null) ?: return
+        val dir = DocumentFile.fromTreeUri(requireContext(), Uri.parse(dirUri)) ?: return
+        dir.findFile("measurements.csv")?.delete()
+    }
+
+    private fun updateExternalPath(uri: Uri) {
+        externalPath.text = uri.path
+    }
+
+    companion object {
+        const val KEY_SAVE_EXTERNAL = "save_external"
+        const val KEY_DIR = "external_dir"
     }
 }

--- a/app/src/main/java/at/plankt0n/openbm64/SettingsFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/SettingsFragment.kt
@@ -63,10 +63,16 @@ class SettingsFragment : Fragment() {
         externalLayout = view.findViewById(R.id.layout_external)
         externalPath = view.findViewById(R.id.text_external_path)
 
-        saveExternalSwitch.isChecked = prefs.getBoolean(KEY_SAVE_EXTERNAL, false)
-        externalLayout.isVisible = saveExternalSwitch.isChecked
+        val dir = prefs.getString(KEY_DIR, null)
+        val enabledPref = prefs.getBoolean(KEY_SAVE_EXTERNAL, false)
+        val enabled = enabledPref && dir != null
+        if (enabled != enabledPref) {
+            prefs.edit().putBoolean(KEY_SAVE_EXTERNAL, enabled).apply()
+        }
+        saveExternalSwitch.isChecked = enabled
+        externalLayout.isVisible = enabled
 
-        prefs.getString(KEY_DIR, null)?.let { updateExternalPath(Uri.parse(it)) }
+        dir?.let { updateExternalPath(Uri.parse(it)) }
 
         saveExternalSwitch.setOnCheckedChangeListener { _, isChecked ->
             if (updatingSwitch) return@setOnCheckedChangeListener

--- a/app/src/main/java/at/plankt0n/openbm64/StorageHelper.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/StorageHelper.kt
@@ -1,0 +1,13 @@
+package at.plankt0n.openbm64
+
+import android.content.Context
+import java.io.File
+
+object StorageHelper {
+    fun internalCsvFile(context: Context): File {
+        val base = context.externalMediaDirs.firstOrNull() ?: context.filesDir
+        val dir = File(base, "openbm64/log")
+        if (!dir.exists()) dir.mkdirs()
+        return File(dir, "measurements.csv")
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/fragment_container"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:menu="@menu/bottom_nav_menu" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_history.xml
+++ b/app/src/main/res/layout/fragment_history.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
+            android:text="Zeitstempel"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Systole"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Diastole"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="MAP"
+            android:textStyle="bold" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Puls"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <ListView
+        android:id="@+id/list_history"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:layout_marginTop="8dp" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -12,6 +12,14 @@
         android:layout_gravity="center_horizontal"
         android:text="@string/read_measurement" />
 
+    <Button
+        android:id="@+id/button_history"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="8dp"
+        android:text="@string/view_history" />
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -12,13 +12,6 @@
         android:layout_gravity="center_horizontal"
         android:text="@string/read_measurement" />
 
-    <Button
-        android:id="@+id/button_history"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:layout_marginTop="8dp"
-        android:text="@string/view_history" />
 
     <ScrollView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,6 +5,27 @@
     android:orientation="vertical"
     android:padding="16dp">
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <ProgressBar
+            android:id="@+id/progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true" />
+
+        <TextView
+            android:id="@+id/text_status"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginStart="8dp"
+            android:text="@string/status_wait_device" />
+    </LinearLayout>
+
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,14 +5,6 @@
     android:orientation="vertical"
     android:padding="16dp">
 
-    <Button
-        android:id="@+id/button_read"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:text="@string/read_measurement" />
-
-
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -1,12 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:padding="16dp">
 
-    <TextView
+    <Switch
+        android:id="@+id/switch_save_external"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/settings_placeholder"
-        android:gravity="center" />
-</FrameLayout>
+        android:text="@string/save_external" />
+
+    <LinearLayout
+        android:id="@+id/layout_external"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:paddingTop="8dp">
+
+        <TextView
+            android:id="@+id/text_external_path"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/no_folder_selected" />
+
+        <Button
+            android:id="@+id/button_choose_folder"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/choose_folder" />
+    </LinearLayout>
+
+    <Button
+        android:id="@+id/button_clear_db"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/clear_db" />
+
+</LinearLayout>
+

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/settings_placeholder"
+        android:gravity="center" />
+</FrameLayout>

--- a/app/src/main/res/layout/item_measurement.xml
+++ b/app/src/main/res/layout/item_measurement.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingVertical="4dp">
+
+    <TextView
+        android:id="@+id/cell_timestamp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="2" />
+
+    <TextView
+        android:id="@+id/cell_systole"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/cell_diastole"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/cell_map"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/cell_pulse"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1" />
+</LinearLayout>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/nav_home"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="@string/nav_home" />
+    <item
+        android:id="@+id/nav_history"
+        android:icon="@android:drawable/ic_menu_recent_history"
+        android:title="@string/nav_history" />
+    <item
+        android:id="@+id/nav_settings"
+        android:icon="@android:drawable/ic_menu_preferences"
+        android:title="@string/nav_settings" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,7 @@
     <string name="confirm_delete">Delete all measurements?</string>
     <string name="confirm_switch_external">Switch to external storage and move file?</string>
     <string name="confirm_switch_internal">Switch to internal storage and move file?</string>
+    <string name="status_wait_device">Warte auf BM64...</string>
+    <string name="status_loading_from">Lade Dateien von %1$s</string>
+    <string name="status_wait_seconds">Warte %1$d Sekunden...</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <resources>
     <string name="app_name">openBM64</string>
     <string name="title_home">Home</string>
-    <string name="read_measurement">Read stored values</string>
     <string name="nav_home">Home</string>
     <string name="nav_history">Historie</string>
     <string name="nav_settings">Einstellungen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="no_folder_selected">No folder selected</string>
     <string name="clear_db">Clear Database</string>
     <string name="confirm_delete">Delete all measurements?</string>
+    <string name="confirm_switch_external">Switch to external storage and move file?</string>
+    <string name="confirm_switch_internal">Switch to internal storage and move file?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
     <string name="nav_history">Historie</string>
     <string name="nav_settings">Einstellungen</string>
     <string name="save_external">Save Measurements Externally</string>
-    <string name="choose_folder">Choose Folder</string>
+    <string name="choose_folder">Change Folder</string>
     <string name="no_folder_selected">No folder selected</string>
     <string name="clear_db">Clear Database</string>
     <string name="confirm_delete">Delete all measurements?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">openBM64</string>
     <string name="title_home">Home</string>
     <string name="read_measurement">Read stored values</string>
+    <string name="view_history">View history</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,5 +2,8 @@
     <string name="app_name">openBM64</string>
     <string name="title_home">Home</string>
     <string name="read_measurement">Read stored values</string>
-    <string name="view_history">View history</string>
+    <string name="nav_home">Home</string>
+    <string name="nav_history">Historie</string>
+    <string name="nav_settings">Einstellungen</string>
+    <string name="settings_placeholder">Settings coming soon</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,5 +5,9 @@
     <string name="nav_home">Home</string>
     <string name="nav_history">Historie</string>
     <string name="nav_settings">Einstellungen</string>
-    <string name="settings_placeholder">Settings coming soon</string>
+    <string name="save_external">Save Measurements Externally</string>
+    <string name="choose_folder">Choose Folder</string>
+    <string name="no_folder_selected">No folder selected</string>
+    <string name="clear_db">Clear Database</string>
+    <string name="confirm_delete">Delete all measurements?</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ espressoCore = "3.6.1"
 appcompat = "1.7.1"
 material = "1.12.0"
 preference = "1.2.1"
+documentfile = "1.1.0-alpha01"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -17,6 +18,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-preference = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }
+androidx-documentfile = { group = "androidx.documentfile", name = "documentfile", version.ref = "documentfile" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- store parsed measurements in a SQLite database
- add a HistoryFragment showing all stored measurements
- implement simple adapter and layouts for a table-like view
- link history screen from home

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b7e31e698832f86325d9db5259d57