### PR TITLE
Fix duplicate log messages

### DIFF
--- a/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
+++ b/app/src/main/java/at/plankt0n/openbm64/HomeFragment.kt
@@ -56,6 +56,10 @@ class HomeFragment : Fragment() {
     private fun appendLog(text: String) {
         activity?.runOnUiThread {
             val tv = logView ?: return@runOnUiThread
+            val current = tv.text.toString()
+            val trimmed = current.trimEnd()
+            val lastLine = trimmed.substringAfterLast('\n', trimmed)
+            if (lastLine == text) return@runOnUiThread
             tv.append(text + "\n")
         }
     }


### PR DESCRIPTION
## Summary
- prevent back-to-back identical log lines

## Testing
- `./gradlew test --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca841564c832fa812a61e70a960a6